### PR TITLE
Fix Typo in QCS Midterm 2026

### DIFF
--- a/Quantum_Computer_Science/Midterm_2026.tex
+++ b/Quantum_Computer_Science/Midterm_2026.tex
@@ -77,7 +77,7 @@ Define the (unnormalized) density matrices
 Express $\mathcal{E}(\ket{\psi_i}\bra{\psi_i}),i\in\{1,2,3,4\}$ as linear combinations of $\{\rho_j\},j\in\{0,1,2,3\}$, then express $\mathcal{E}(\rho_i),i\in\{0,1,2,3\}$ as linear combinations of $\{\rho_j\},j\in\{0,1,2,3\}$.\\
 (4) Find out the Kraus operator-sum representation of the general operation.\\
 Hint: We first define
-\[E_0=I,E_1=Z,E_2=-iY,E_3=Z.\]
+\[E_0=I,E_1=Z,E_2=-iY,E_3=X.\]
 We see that they form a basis of the operator space on a single qubit, and therefore the actual Kraus operators can be expressed as
 \[F_i=\sum_me_{im}E_m,\]
 which gives


### PR DESCRIPTION
Fixed typo Q3 E_3=Z -->E_3=X